### PR TITLE
Updated the Boost_Master code to version 3.7 to use the latest versio…

### DIFF
--- a/app/src/main/assets/Boost/determine-basal.js
+++ b/app/src/main/assets/Boost/determine-basal.js
@@ -255,7 +255,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     //*********************************************************************************
 
         console.error("---------------------------------------------------------");
-        console.error( "     Boost version 3.6.5 ");
+        console.error( "     Boost version: 3.7                 ");
         console.error("---------------------------------------------------------");
 
     if (meal_data.TDDAIMI7){
@@ -273,12 +273,17 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         var tdd8to4 = meal_data.TDD4to8;
         var tdd_last8_wt = ( ( ( 1.4 * tdd_4) + ( 0.6 * tdd8to4) ) * 3 );
         var tdd8_exp = ( 3 * tdd_8 );
-        console.log("8 hour extrapolated = " +tdd8_exp+ "; ");
+        //console.log("8 hour extrapolated = " +tdd8_exp+ "; ");
 
+
+        if ( tdd_last8_wt < (0.75 * tdd7)) {
+            tdd7 = tdd_last8_wt + ( ( tdd_last8_wt / tdd7 ) * ( tdd7 - tdd_last8_wt ) );
+            console.log(" Current TDD use below 75% of TDD7; adjusting TDD7 down to: "+tdd7+"; ");
+        }
+        else {
+            console.log("Normal TDD calculation used");
+        }
         TDD = ( tdd_last8_wt * 0.33 ) + ( tdd7 * 0.34 ) + (tdd1 * 0.33);
-        console.log("TDD = " +TDD+ " using rolling 8h Total extrapolation + TDD7 (60/40); ");
-        //var TDD = (tdd7 * 0.4) + (tdd_24 * 0.6);
-
        console.error("                                 ");
        //console.error("7-day average TDD is: " +tdd7+ "; ");
        console.error("Rolling 8 hours weight average: "+tdd_last8_wt+"; ");
@@ -288,7 +293,15 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     var dynISFadjust = profile.DynISFAdjust;
     var dynISFadjust = ( dynISFadjust / 100 );
+
+    var profileSwitch = profile.profilePercent;
+
+    console.error("Current Profile percent: "+profileSwitch+"; ");
+
+    dynISFadjust = dynISFadjust * (profileSwitch / 100);
     var TDD = (dynISFadjust * TDD);
+
+    console.error("Adjusted TDD = "+TDD+"; ");
 
     var insulin = profile.insulinType;
 
@@ -668,6 +681,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             , 'deliverAt' : deliverAt // The time at which the microbolus should be delivered
             , 'sensitivityRatio' : sensitivityRatio // autosens ratio (fraction of normal basal)
             , 'Total Daily Dose 7-day Ave' : tdd7 //7 day average tdd
+            , 'variable_sens' : sens
         };
 
     // generate predicted future BGs based on IOB, COB, and current absorption rate
@@ -822,9 +836,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             // for IOBpredBGs, predicted deviation impact drops linearly from current deviation down to zero
             // over 60 minutes (data points every 5m)
             var predDev = ci * ( 1 - Math.min(1,IOBpredBGs.length/(60/5)) );
-            IOBpredBG = IOBpredBGs[IOBpredBGs.length-1] + predBGI + predDev;
+            //IOBpredBG = IOBpredBGs[IOBpredBGs.length-1] + predBGI + predDev;
+            IOBpredBG = IOBpredBGs[IOBpredBGs.length-1] + (round(( -iobTick.activity * (1800 / ( TDD * (Math.log((Math.max( IOBpredBGs[IOBpredBGs.length-1],39) / ins_val ) + 1 ) ) )) * 5 ),2))
+
+             + predDev;
             // calculate predBGs with long zero temp without deviations
-            var ZTpredBG = ZTpredBGs[ZTpredBGs.length-1] + predZTBGI;
+            var ZTpredBG = ZTpredBGs[ZTpredBGs.length-1] + (round(( -iobTick.iobWithZeroTemp.activity * (1800 / ( TDD * (Math.log(( Math.max(ZTpredBGs[ZTpredBGs.length-1],39) / ins_val ) + 1 ) ) )) * 5 ), 2));
             // for COBpredBGs, predicted carb impact drops linearly from current carb impact down to zero
             // eventually accounting for all carbs (if they can be absorbed over DIA)
             var predCI = Math.max(0, Math.max(0,ci) * ( 1 - COBpredBGs.length/Math.max(cid*2,1) ) );
@@ -853,7 +870,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 //console.error(UAMpredBGs.length,slopeFromDeviations, predUCI);
                 UAMduration=round((UAMpredBGs.length+1)*5/60,1);
             }
-            UAMpredBG = UAMpredBGs[UAMpredBGs.length-1] + predBGI + Math.min(0, predDev) + predUCI;
+            UAMpredBG = UAMpredBGs[UAMpredBGs.length-1] + (round(( -iobTick.activity * (1800 / ( TDD * (Math.log(( Math.max(UAMpredBGs[UAMpredBGs.length-1],39) / ins_val ) + 1 ) ) )) * 5 ),2)) + Math.min(0, predDev) + predUCI;
             //console.error(predBGI, predCI, predUCI);
             // truncate all BG predictions at 4 hours
             if ( IOBpredBGs.length < 48) { IOBpredBGs.push(IOBpredBG); }
@@ -869,9 +886,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
             // set minPredBGs starting when currently-dosed insulin activity will peak
             // look ahead 60m (regardless of insulin type) so as to be less aggressive on slower insulins
-            var insulinPeakTime = 60;
-            // add 30m to allow for insulin delivery (SMBs or temps)
-            insulinPeakTime = 90;
+
+            //var insulinPeakTime = 60;
+            // change look ahead to use actual peak time from config and add 30m to allow for insulin delivery (SMBs or temps)
+            insulinPeakTime = insulinPeak + 30;
             var insulinPeak5m = (insulinPeakTime/60)*12;
             //console.error(insulinPeakTime, insulinPeak5m, profile.insulinPeakTime, profile.curve);
 
@@ -962,13 +980,18 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
         console.log("EventualBG is" +eventualBG+" ;");
 
+    var now1 = new Date().getHours();
+    var boost_start = profile.boost_start;
+    var boost_end = profile.boost_end;
+
+
         if( meal_data.mealCOB > 0 && delta_accl > 0 ) {
 
             var future_sens = ( 1800 / (Math.log((((eventualBG * 0.75) + (bg * 0.25))/ins_val)+1)*TDD));
             console.log("Future state sensitivity is " +future_sens+" weighted on eventual BG due to COB");
             rT.reason += "Dosing sensitivity: " +future_sens+" weighted on predicted BG due to COB;";
             }
-        else if( glucose_status.delta > 4 && delta_accl > 10 && bg < 180 && eventualBG > bg ) {
+        else if( glucose_status.delta > 4 && delta_accl > 10 && bg < 180 && eventualBG > bg && now1 >= boost_start && now1 < boost_end ) {
 
             var future_sens = ( 1800 / (Math.log((((eventualBG * 0.5) + (bg * 0.5))/ins_val)+1)*TDD));
             console.log("Future state sensitivity is " +future_sens+" weighted on predicted bg due to increasing deltas");
@@ -980,7 +1003,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             console.log("Future state sensitivity is " +future_sens+" weighted on current bg due to no COB");
             rT.reason += "Dosing sensitivity: " +future_sens+" weighted on current BG;";
             }*/
-        else if( bg > 160 && bg < 270 && glucose_status.delta < 2 && glucose_status.delta > -2 && glucose_status.short_avgdelta > -2 && glucose_status.short_avgdelta < 2 && eventualBG < bg) {
+       /* else if( bg > 160 && bg < 270 && glucose_status.delta < 2 && glucose_status.delta > -2 &&
+       glucose_status.short_avgdelta > -2 && glucose_status.short_avgdelta < 2 && eventualBG < bg) {
             var future_sens = ( 1800 / (Math.log((((minPredBG * 0.6) + (bg * 0.4))/ins_val)+1)*TDD));
             console.log("Future state sensitivity is " +future_sens+" using current bg due to no COB & small delta or variation");
             rT.reason += "Dosing sensitivity: " +future_sens+" using current BG;";
@@ -997,7 +1021,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
         else {
             var future_sens = ( 1800 / (Math.log((Math.max(minPredBG,1)/ins_val)+1)*TDD));
-        console.log("Future state sensitivity is " +future_sens+" based on min predited bg due to -ve delta");
+        console.log("Future state sensitivity is " +future_sens+" based on min predicted bg due to -ve delta");
         rT.reason += "Dosing sensitivity: " +future_sens+" using eventual BG;";
         }
         //future_sens = future_sens * circadian_sensitivity;
@@ -1397,7 +1421,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 var bga = Math.abs(bg-180);
                 var bg_adjust = bga / 40;
                 //console.error("bg_adjust value is "+bg_adjust+"; ");
-                var insulinDivisor = insulinReqPCT - Math.min((insulinPCTsubtract * bg_adjust),0.76);
+                //var insulinDivisor = insulinReqPCT - Math.min((insulinPCTsubtract * bg_adjust),0.)
+                var insulinDivisor =  (insulinReqPCT - ((Math.abs(bg-180) / 72 ) * ( insulinReqPCT - 0.5)));
                 console.error("Insulin Divisor is:"+insulinDivisor+"; ");
                 console.error("            ");
                 console.error("Value is "+((1/insulinDivisor) * 100)+"% of insulin required; ");
@@ -1425,7 +1450,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 console.error("Max IOB from automated boluses = "+boostMaxIOB+"; ");
                 console.error("            ");
 
-                var now1 = new Date().getHours();
+                //var now1 = new Date().getHours();
 
                 if (now1 >= profile.boost_start && now1 <= profile.boost_end) {
                     console.error("Hours are now "+now1+", so UAM Boost is enabled;");
@@ -1433,8 +1458,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                     console.error("Hours are now "+now1+", so UAM Boost is disabled;");
                 }
 
-                var boost_start = profile.boost_start;
-                var boost_end = profile.boost_end;
+                /*var boost_start = profile.boost_start;
+                var boost_end = profile.boost_end;*/
                 var boost_max = profile.boost_bolus;
                 console.error("            ");
                 console.error("Max automated bolus is "+boost_max+"; ");
@@ -1500,7 +1525,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                      boostInsulinReq = boostInsulinReq;
                      }
                      if(delta_accl > 1){
-                         insulinReqPCT = 1;
+                         insulinReqPCT = insulinDivisor;
                          }
                      else{
                          insulinReqPCT;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/Boost/DetermineBasalAdapterBoostJS.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/Boost/DetermineBasalAdapterBoostJS.kt
@@ -4,6 +4,7 @@ import dagger.android.HasAndroidInjector
 import info.nightscout.androidaps.R
 import info.nightscout.androidaps.data.IobTotal
 import info.nightscout.androidaps.data.MealData
+import info.nightscout.androidaps.data.ProfileSealed
 import info.nightscout.androidaps.extensions.convertedToAbsolute
 import info.nightscout.androidaps.extensions.getPassedDurationToTimeInMinutes
 import info.nightscout.androidaps.extensions.plannedRemainingMinutes
@@ -229,6 +230,7 @@ class DetermineBasalAdapterBoostJS internal constructor(private val scriptReader
         this.profile.put("DynISFAdjust",  SafeParse.stringToDouble(sp.getString(R.string.key_DynISFAdjust,"100")))
         this.profile.put("insulinType", insulinType)
         this.profile.put("insulinPeak", insulinPeak)
+        this.profile.put("profilePercent",  if (profile is ProfileSealed.EPS) profile.value.originalPercentage else 100)
 
         //set the min SMB amount to be the amount set by the pump.
         this.profile.put("bolus_increment", pumpBolusStep)


### PR DESCRIPTION
…n from Test Platform:

Main changes:

1. Dosing ISF only uses higher eventual BG when Boost hours are set.
2. Prediction curves for UAM, ZT and IOB all use the dynamic ISF calculation to determine ISF at each point.
3. ISF scales up and down with profile % adjustments.
4. When 8hr weighted average TDD estimate is below 75% of 7-day average TDD, TDD value is lowered. 5, Insulin peak time for look ahead uses profile insulin peak, not hardcoded 60 mins.
6. Boost delivery can scale from 200% at lower glucose levels.